### PR TITLE
chore: make package Desktop compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "@exodus/react-native-web-linear-gradient",
   "version": "1.1.2-exodus.0",
   "description": "React Native for Web implementation of react-native-linear-gradient",
-  "main": "dist/index.js",
-  "main-es": "src/index.js",
+  "main": "src/index.js",
   "repository": "https://github.com/react-native-web-community/react-native-web-linear-gradient",
   "author": {
     "name": "Louis Lagrange",
@@ -28,9 +27,7 @@
     ]
   },
   "files": [
-    "src",
-    "dist",
-    "yarn.lock"
+    "src"
   ],
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-web-linear-gradient",
-  "version": "1.1.2",
+  "name": "@exodus/react-native-web-linear-gradient",
+  "version": "1.1.2-exodus.0",
   "description": "React Native for Web implementation of react-native-linear-gradient",
   "main": "dist/index.js",
   "main-es": "src/index.js",


### PR DESCRIPTION
## Summary 

After adding `react-native-web-linear-gradient` as a Desktop dependency, we encountered some issues that prevented us from getting the app running (see [Slack thread](https://exodusio.slack.com/archives/C019BPCLTPT/p1640879604446600) for more details). We decided in [the thread](https://exodusio.slack.com/archives/C019BPCLTPT/p1640879604446600) that forking the package is the best solution.